### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/ProblemDetailsDemo.Api/ProblemDetailsDemo.Api.csproj
+++ b/src/ProblemDetailsDemo.Api/ProblemDetailsDemo.Api.csproj
@@ -11,12 +11,12 @@
   <ItemGroup>
     <PackageReference Include="CcAcca.LogDimensionCollection.AppInsights" Version="2.0.0" />
     <PackageReference Include="CcAcca.LogDimensionCollection.AspNetCore" Version="1.2.2" />
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="5.3.0" />
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="5.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
     <PackageReference Include="CcAcca.ApplicationInsights.ProblemDetails" Version="1.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.10.8" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.10.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi@christianacca, I found an issue in the ProblemDetailsDemo.Api.csproj:

Packages Hellang.Middleware.ProblemDetails v5.3.0, Microsoft.VisualStudio.Web.CodeGeneration.Design v3.1.0 and NSwag.AspNetCore v13.10.8 transitively introduce 183 dependencies into ProblemDetailsDemo’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/ProblemDetailsDemo.html)), while Hellang.Middleware.ProblemDetails v5.4.0, Microsoft.VisualStudio.Web.CodeGeneration.Design v3.1.1 and NSwag.AspNetCore v13.10.9 can only introduce 138 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/ProblemDetailsDemo_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose